### PR TITLE
Correct `DiskStore` into `DiskStorage`

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ PyPi is not used for CaskDB yet ([issue #5](https://github.com/avinassh/py-caskd
 ## Usage
 
 ```python
-disk: DiskStorage = DiskStore(file_name="books.db")
+disk: DiskStorage = DiskStorage(file_name="books.db")
 disk.set(key="othello", value="shakespeare")
 author: str = disk.get("othello")
 # it also supports dictionary style API too:

--- a/src/caskdb/disk_store.py
+++ b/src/caskdb/disk_store.py
@@ -13,7 +13,7 @@ we cannot use the database.
 
 Typical usage example:
 
-    disk: DiskStorage = DiskStore(file_name="books.db")
+    disk: DiskStorage = DiskStorage(file_name="books.db")
     disk.set(key="othello", value="shakespeare")
     author: str = disk.get("othello")
     # it also supports dictionary style API too:


### PR DESCRIPTION
Example codes written in `README.md` and `src/caskdb/disk_store.py` initialize storage with `DiskStore`. However, this is not working because we need to initialize storage with `DiskStorage` instead of `DiskStore`.
Therefore, I corrected `DiskStore` into `DiskStorage`.

If the usage of `DiskStore` is intended or my PR is wrong, please close it.